### PR TITLE
Fix document.head is null if there is a comment before head

### DIFF
--- a/OCGumbo/OCGumbo.h
+++ b/OCGumbo/OCGumbo.h
@@ -18,6 +18,7 @@
 
 //please add gumbo(https://github.com/google/gumbo-parser/tree/master/src) sources or lib to the project.
 #include "gumbo.h"
+#import <Foundation/Foundation.h>
 
 //for OCGumbo+Query.
 id OCGumboNodeCast(GumboNode *node);

--- a/OCGumbo/OCGumbo.m
+++ b/OCGumbo/OCGumbo.m
@@ -77,13 +77,7 @@ NS_INLINE GumboNode *oc_gumbo_get_firstchild(GumboNode *node) {
 }
 
 NS_INLINE GumboNode *oc_gumbo_get_first_element_by_tag(GumboNode *node, GumboTag tag) {
-    GumboNode *root = NULL;
-    if (node->type == GUMBO_NODE_DOCUMENT) {
-        root = oc_gumbo_get_firstchild(node);
-    } else {
-        root = node;
-    }
-    
+    GumboNode *root = node;
     int count = oc_gumbo_get_child_cout(root);
     for (int i = 0; i < count; i++) {
         GumboNode *child = oc_gumbo_get_child_at_index(root, i);


### PR DESCRIPTION
The example fails while running at line 76 in main.m

`NSArray *rows = iosfeedDoc.body.Query(@"div.row").find(@"div.media-body");`

While calling `document.body`, it first try to retrieve the first child node of document. Then, it test all child node until finding the body. However, the first child node of the document is unpredictable. The node can be either element or comment. The document retrieved from [http://www.iosfeed.com](url) starts with a comment.

This change trades all node equally. For a document node, it can still find the title, head, body.
